### PR TITLE
[WIP] Parametrize sssctl tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: "ci"
 on:
   push:
-    branches: [master, test-plan]
+    branches: [master]
   pull_request:
-    branches: [master, test-plan]
+    branches: [master]
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: "ci"
 on:
   push:
-    branches: [master]
+    branches: [master, test-plan]
   pull_request:
-    branches: [master]
+    branches: [master, test-plan]
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/src/tests/system/tests/test_access_control.py
+++ b/src/tests/system/tests/test_access_control.py
@@ -53,7 +53,7 @@ test_001_simple_allow_user_to_user1 -> test_access_control.py
 notes
 =====
 * parametrize the search attributes, allowing ad and ldap filters be one test
-* parametrize fully qualified names 
+* parametrize fully qualified names
 """
 
 

--- a/src/tests/system/tests/test_autofs.py
+++ b/src/tests/system/tests/test_autofs.py
@@ -24,7 +24,7 @@ b:blocked
 discussions
 ===========
 ?:expand these tests to create files, directories and assert ownership
-?:extend samba and ad role and create cifs share 
+?:extend samba and ad role and create cifs share
 
 intg
 ====

--- a/src/tests/system/tests/test_dns.py
+++ b/src/tests/system/tests/test_dns.py
@@ -49,7 +49,7 @@ DNS(BaseObject[ADHost, AD])
 
 # in our existing tests we had to disable forwarders in AD otherwise the internal rh corp ptr record would resolve
   role.ad.dns.zone(name: str | None = domain, secure_updates: bool | None = True)
-DNS over TLS (DoT)  
+DNS over TLS (DoT)
 Certificates for client
 SSSD Client configuration?
 
@@ -57,15 +57,15 @@ update containers to support dot, SSSD_container repo (jakub)
 * client (networkManager)
 * new ipa topologycontroller with dot enabled, sssd configured client
 
-eDNS in RHEL (anaconda,..., installer, dnsconfd... ), /etc/edns/trust (custom trust store) due to UKI issues...  
-- - eDNS in RHEL IdM (SSSD and IPA), 
+eDNS in RHEL (anaconda,..., installer, dnsconfd... ), /etc/edns/trust (custom trust store) due to UKI issues...
+- - eDNS in RHEL IdM (SSSD and IPA),
 https://github.com/freeipa/freeipa/pull/7343/commits
 
 
 https://github.com/freeipa/freeipa/pull/7343/commits/5abccbf9f4169b2379fccda8677700ae28c1b4c8
 - test_edns (deploying freeipa with DoT enable, and supports Server, replicas, and clients)
 
-https://github.com/SSSD/sssd/pull/7678 ---dot support in sssd 
+https://github.com/SSSD/sssd/pull/7678 ---dot support in sssd
 dyndns_dot_cacert
 dyndns_dot_cert
 """

--- a/src/tests/system/tests/test_files.py
+++ b/src/tests/system/tests/test_files.py
@@ -27,7 +27,7 @@ b:blocked
 notes
 =====
 * I think we should drop most of these tests except the ones that checks the data that is extracted from /etc/passwd, homedir, gecos
-* Dropping the modifying value entry tests, cache tests, override tests 
+* Dropping the modifying value entry tests, cache tests, override tests
 
 intg
 ====

--- a/src/tests/system/tests/test_memcache.py
+++ b/src/tests/system/tests/test_memcache.py
@@ -28,7 +28,7 @@ b:blocked
 notes
 =====
 * single provider, no value testing against multiple providers
-* this can be parametrized, I think it'll be easier to parametrized the service, because the assertions for users and groups are so different. 
+* this can be parametrized, I think it'll be easier to parametrized the service, because the assertions for users and groups are so different.
 * is it important to invalidate a user and then users? and a group and groups?
 
 

--- a/src/tests/system/tests/test_sssctl.py
+++ b/src/tests/system/tests/test_sssctl.py
@@ -16,7 +16,6 @@ from sssd_test_framework.roles.client import Client
 from sssd_test_framework.roles.ldap import LDAP
 from sssd_test_framework.topology import KnownTopology
 
-
 """
 ?:needs review
 p:pushed
@@ -31,12 +30,26 @@ notes
 bash
 ====
 # sssctl.sh
-?:sssctl config check
-?:sssctl domain list
-?:sssctl user checks
-?:sssctl check cache for user
-?:sssctl check cache for group
-?:sssctl check cache for netgroup
+-:sssctl config check
+    Covered by:
+        src/tests/system/tests/test_sssctl:test_sssctl__check_invalid_section_name
+-:sssctl domain list
+    Covered by:
+        src/tests/multihost/alltests/test_sssctl_ldap.py:test_0009_bz1751691
+        src/tests/multihost/ipa/test_adtrust.py:TestADTrust.test_basic_sssctl_list
+-:sssctl user checks
+    Covered by:
+        src/tests/system/tests/test_infopipe.py:test_infopipe__lookup_user_with_extra_attributes
+        src.tests.multihost.alltests.test_sssctl_ldap:Testsssctl
+-:sssctl check cache for user
+    Covered by:
+        src/tests/intg/test_sssctl.py:test_user_show_basic_sanity
+-:sssctl check cache for group
+    Covered by:
+        src/tests/intg/test_sssctl.py:test_user_show_basic_fqname_insensitive
+-:sssctl check cache for netgroup
+    Covered by:
+        src/tests/intg/test_sssctl.py:test_netgroup_show
 ?:sssctl backup and restore local data
 ?:sssctl truncating logs
 ?:sssctl output timezone and local timezone bz1356577
@@ -85,83 +98,6 @@ multihost
 ?:test_0002_bz1599207
 ?:test_0003_bz1661182
 """
-
-
-@pytest.mark.parametrize("section", ["pam", "nss", "sssd"])
-def test_sssctl__invalid_section_name(section: str):
-    """
-    :title: The section name contains a typographical error and will be caught
-
-    Covers
-    test_sssctl__check_invalid_pam_section
-    test_sssctl__check_invalid_nss_section
-    test_sssctl__check_invalid_sssd_section
-
-    should we add [sudo] and other sections?
-    """
-    pass
-
-
-@pytest.mark.importance("high")
-@pytest.mark.tools
-@pytest.mark.ticket(bz=2100789)
-@pytest.mark.topology(KnownTopology.LDAP)
-def test_sssctl__check_missing_id_provider(client: Client):
-    """
-    :title: Check id_provider in domain section with sssctl config-check command
-    :setup:
-        1. Create the sssd.conf, here we are using provider as a LDAP server
-    :steps:
-        1. Remove id_provider from domain section.
-        2. Check error message using sssctl config-check.
-    :expectedresults:
-        1. Successfully remove id_provider from domain section.
-        2. Successfully get the error message.
-    :customerscenario: False
-    """
-    # create sssd.conf and start the sssd, with default configuration with a LDAP server.
-    client.sssd.start()
-
-    # remove id_provider parameter from domain section.
-    client.sssd.config.remove_option("domain/test", "id_provider")
-    client.sssd.config_apply(check_config=False)
-
-    # Check the error message in output of # sssctl config-check
-    output = client.host.conn.run("sssctl config-check", raise_on_error=False)
-    assert "[rule/sssd_checks]: Attribute 'id_provider' is missing in section 'domain/test'." in output.stdout_lines[1]
-
-
-@pytest.mark.importance("high")
-@pytest.mark.tools
-@pytest.mark.ticket(bz=2100789)
-@pytest.mark.topology(KnownTopology.LDAP)
-def test_sssctl__check_invalid_id_provider(client: Client):
-    """
-    :title: Check id_provider in domain section with sssctl config-check command with provider
-    :setup:
-        1. Create the sssd.conf, here we are using provider as a LDAP server
-    :steps:
-        1. Add invalid, id_provider's value to domain section.
-        2. Check error message using sssctl config-check.
-    :expectedresults:
-        1. Successfully remove id_provider from domain section.
-        2. Successfully get the error message.
-    :customerscenario: False
-    """
-    # create sssd.conf and start the sssd, with deafult configuration with a LDAP server.
-    client.sssd.start()
-
-    # Add 'invalid' as a id_provider's value in domain section.
-    client.sssd.config.remove_option("domain/test", "id_provider")
-    client.sssd.domain["id_provider"] = "invalid"
-    client.sssd.config_apply(check_config=False)
-
-    # Check the return code of # sssctl config-check command
-    output = client.host.conn.run("sssctl config-check", raise_on_error=False)
-    assert (
-        "[rule/sssd_checks]: Attribute 'id_provider' in section 'domain/test' has an invalid value: invalid"
-        in output.stdout_lines[1]
-    )
 
 
 @pytest.mark.ticket(bz=1640576)
@@ -278,32 +214,6 @@ def test_sssctl__reset_cached_timestamps_to_reflect_changes(client: Client, ldap
 @pytest.mark.importance("high")
 @pytest.mark.tools
 @pytest.mark.topology(KnownTopology.Client)
-def test_sssctl__check_invalid_option_name(client: Client):
-    """
-    :title: sssctl config-check detects mistyped option name
-    :setup:
-        1. Add wrong_option to domain section
-        2. Apply config
-    :steps:
-        1. Call sssctl config-check
-        2. Check error message
-    :expectedresults:
-        1. config-check detects an error in config
-        2. Error message is properly set
-    :customerscenario: False
-    """
-    client.sssd.common.local()
-    client.sssd.dom("test")["wrong_option"] = "true"
-    client.sssd.config_apply(check_config=False)
-
-    result = client.sssctl.config_check()
-    assert result.rc != 0, "Config-check did not detect misconfigured config, when SSSD is running"
-    assert "Attribute 'wrong_option' is not allowed" in result.stdout, "Wrong error message was returned"
-
-
-@pytest.mark.importance("high")
-@pytest.mark.tools
-@pytest.mark.topology(KnownTopology.Client)
 def test_sssctl__check_missing_domain_name(client: Client):
     """
     :title: sssctl config-check detects mistyped domain name
@@ -326,38 +236,16 @@ def test_sssctl__check_missing_domain_name(client: Client):
     assert ex.match(r"Section \[domain\/\] is not allowed. Check for typos.*"), "Wrong error message was returned"
 
 
-@pytest.mark.importance("high")
 @pytest.mark.tools
 @pytest.mark.topology(KnownTopology.Client)
-def test_sssctl__check_misplaced_option(client: Client):
-    """
-    :title: sssctl config-check detects misplaced option
-    :setup:
-        1. In domain set "services" to "nss, pam"
-        2. Start SSSD, without config check
-    :steps:
-        1. Call sssctl config-check
-        2. Check error message
-    :expectedresults:
-        1. config-check detects an error in config
-        2. Error message is properly set
-    :customerscenario: False
-    """
-    client.sssd.common.local()
-    client.sssd.dom("test")["services"] = "nss, pam"
-
-    client.sssd.start(check_config=False)
-
-    result = client.sssctl.config_check()
-    assert result.rc != 0, "Config-check did not detect misconfigured config"
-
-    pattern = re.compile(r".Attribute 'services' is not allowed in section .*")
-    assert pattern.search(result.stdout), "Wrong error message was returned"
-
-
-@pytest.mark.tools
-@pytest.mark.topology(KnownTopology.Client)
-def test_sssctl__check_invalid_option_name_in_snippet(client: Client):
+@pytest.mark.parametrize(
+    "contents,expected",
+    [
+        ("[domain/local]\ninvalid_option = True", "Attribute 'invalid_option' is not allowed"),
+        ("[invalid/local]\ninvalid_option = True", "Section [invalid/local] is not allowed"),
+    ],
+)
+def test_sssctl__check_invalid_option_name_in_snippet(client: Client, contents, expected):
     """
     :title: sssctl config-check detects invalid option name in snippet
     :setup:
@@ -371,44 +259,46 @@ def test_sssctl__check_invalid_option_name_in_snippet(client: Client):
     :customerscenario: False
     """
     client.sssd.common.local()
-    client.fs.write("/etc/sssd/conf.d/01_snippet.conf", "[domain/local]\ninvalid_option = True", mode="600")
+    client.fs.write("/etc/sssd/conf.d/01_snippet.conf", contents, mode="600")
 
     result = client.sssctl.config_check()
     assert result.rc != 0, "Config-check did not detect misconfigured config snippet"
-    assert "Attribute 'invalid_option' is not allowed" in result.stdout, "Wrong error message was returned"
+    assert expected in result.stdout, "Wrong error message was returned"
 
 
+@pytest.mark.parametrize(
+    "pattern,repl,expected",
+    [
+        ("id_provider = ", "id_provider ", ("Equal sign is missing", "stderr")),
+        pytest.param(
+            "id_provider.*",
+            "id_provider = invalid",
+            ("Attribute 'id_provider' in section 'domain/local' has an invalid value: invalid", "stdout"),
+            marks=[pytest.mark.ticket(bz=2100789), pytest.mark.importance("high")],
+        ),
+        pytest.param(
+            "id_provider.*",
+            "",
+            ("Attribute 'id_provider' is missing in section 'domain/local'.", "stdout"),
+            marks=[pytest.mark.ticket(bz=2100789), pytest.mark.importance("high")],
+        ),
+        ("id_provider", "id_@provider", ("Attribute 'id_@provider' is not allowed in section", "stdout")),
+        ("domain/", "d$main/", ("Section [d$main/local] is not allowed", "stdout")),
+        ("domain/local", "domain/local@", ("Section [domain/local@] is not allowed", "stdout")),
+        ("domain/local", "domainlocal", ("Section [domainlocal] is not allowed", "stdout")),
+        (".sssd.", "[sssdx]", ("Section [sssdx] is not allowed", "stdout")),
+        (".nss.", "[nssx", ("No closing bracket", "stderr")),
+        (".domain/local.", "domain/local]", ("Equal sign is missing", "stderr")),
+    ],
+)
 @pytest.mark.tools
 @pytest.mark.topology(KnownTopology.Client)
-def test_sssctl__check_invalid_section_in_name_in_snippet(client: Client):
+def test_sssctl__check_invalid_section_name(client: Client, pattern, repl, expected):
     """
-    :title: sssctl config-check detects invalid domain name in snippet
-    :setup:
-        1. Create new conf snippet with invalid domain name
-    :steps:
-        1. Call sssctl config-check
-        2. Check error message
-    :expectedresults:
-        1. config-check detects an error in config snippet
-        2. Error message is properly set
-    :customerscenario: False
-    """
-    client.sssd.common.local()
-    client.fs.write("/etc/sssd/conf.d/01_snippet.conf", "[invalid/local]\ninvalid_option = True", mode="600")
-
-    result = client.sssctl.config_check()
-    assert result.rc != 0, "Config-check did not detect misconfigured config snippet"
-    assert "Section [invalid/local] is not allowed" in result.stdout, "Wrong error message was returned"
-
-
-@pytest.mark.tools
-@pytest.mark.topology(KnownTopology.Client)
-def test_sssctl__check_missing_equal_sign(client: Client):
-    """
-    :title: sssctl config-check detects missing equals sign
+    :title: sssctl config-check detects mistyped section name
     :setup:
         1. Start SSSD, so default config is automatically created
-        2. Edit config file so "=" is missing
+        2. Edit config file so that it contains mistyped section name
     :steps:
         1. Call sssctl config-check
         2. Check error message
@@ -419,272 +309,12 @@ def test_sssctl__check_missing_equal_sign(client: Client):
     """
     client.sssd.common.local()
     client.sssd.start()
-    conf = re.sub("id_provider = ", "id_provider ", client.fs.read("/etc/sssd/sssd.conf"))
+    conf = re.sub(pattern, repl, client.fs.read("/etc/sssd/sssd.conf"))
     client.fs.write("/etc/sssd/sssd.conf", conf, mode="600")
 
     result = client.sssctl.config_check()
     assert result.rc != 0, "Config-check did not detect misconfigured config"
-    assert "Equal sign is missing" in result.stderr, "Wrong error message on stderr"
-
-
-@pytest.mark.tools
-@pytest.mark.topology(KnownTopology.Client)
-def test_sssctl__check_special_character_in_option_name(client: Client):
-    """
-    :title: option name contains special character
-    :setup:
-        1. Start SSSD, so default config is autimatically created
-        2. Edit config file in a way that it contains special character
-    :steps:
-        1. Call sssctl config-check
-        2. Check error message
-    :expectedresults:
-        1. config-check detects an error
-        2. Error message is properly set
-    :customerscenario: False
-    """
-    client.sssd.common.local()
-    client.sssd.start()
-    conf = re.sub("id_provider", "id_@provider", client.fs.read("/etc/sssd/sssd.conf"))
-    client.fs.write("/etc/sssd/sssd.conf", conf, mode="600")
-
-    result = client.sssctl.config_check()
-    assert result.rc != 0, "Config-check did not detect misconfigured config"
-    assert "Attribute 'id_@provider' is not allowed in section" in result.stdout, "Wrong error message on stdout"
-
-
-@pytest.mark.tools
-@pytest.mark.topology(KnownTopology.Client)
-def test_sssctl__check_special_character_in_section_name(client: Client):
-    """
-    :title: section name contains special character
-    :setup:
-        1. Start SSSD, so default config is autimatically created
-        2. Edit config file in a way that it contains special character
-    :steps:
-        1. Call sssctl config-check
-        2. Check error message
-    :expectedresults:
-        1. config-check detects an error
-        2. Error message is properly set
-    :customerscenario: False
-    """
-    client.sssd.common.local()
-    client.sssd.start()
-    conf = re.sub("domain/", "d$main/", client.fs.read("/etc/sssd/sssd.conf"))
-    client.fs.write("/etc/sssd/sssd.conf", conf, mode="600")
-
-    result = client.sssctl.config_check()
-    assert result.rc != 0, "Config-check did not detect misconfigured config"
-    assert "Section [d$main/local] is not allowed" in result.stdout, "Wrong error message on stdout"
-
-
-@pytest.mark.tools
-@pytest.mark.topology(KnownTopology.Client)
-def test_sssctl__check_special_character_in_domain_name(client: Client):
-    """
-    :title: domain name contains special character
-    :setup:
-        1. Start SSSD, so default config is autimatically created
-        2. Edit config file in a way that it contains special character
-    :steps:
-        1. Call sssctl config-check
-        2. Check error message
-    :expectedresults:
-        1. config-check detects an error
-        2. Error message is properly set
-    :customerscenario: False
-    """
-    client.sssd.common.local()
-    client.sssd.start()
-    conf = re.sub("domain/local", "domain/local@", client.fs.read("/etc/sssd/sssd.conf"))
-    client.fs.write("/etc/sssd/sssd.conf", conf, mode="600")
-
-    result = client.sssctl.config_check()
-    assert result.rc != 0, "Config-check did not detect misconfigured config"
-    assert "Section [domain/local@] is not allowed" in result.stdout, "Wrong error message on stdout"
-
-
-@pytest.mark.tools
-@pytest.mark.topology(KnownTopology.Client)
-def test_sssctl__check_forward_slash_missing_in_domain_section(client: Client):
-    """
-    :title: Forward slash is not present between domain name and section name
-    :setup:
-        1. Start SSSD, so default config is autimatically created
-        2. Edit config file in a way that forward slash is missing in section name
-    :steps:
-        1. Call sssctl config-check
-        2. Check error message
-    :expectedresults:
-        1. config-check detects an error
-        2. Error message is properly set
-    :customerscenario: False
-    """
-    client.sssd.common.local()
-    client.sssd.start()
-    conf = re.sub("domain/local", "domainlocal", client.fs.read("/etc/sssd/sssd.conf"))
-    client.fs.write("/etc/sssd/sssd.conf", conf, mode="600")
-
-    result = client.sssctl.config_check()
-    assert result.rc != 0, "Config-check did not detect misconfigured config"
-    assert "Section [domainlocal] is not allowed" in result.stdout, "Wrong error message on stdout"
-
-
-@pytest.mark.tools
-@pytest.mark.topology(KnownTopology.Client)
-def test_sssctl__check_invalid_sssd_section_name(client: Client):
-    """
-    :title: Typo in sssd section name
-    :setup:
-        1. Start SSSD, so default config is autimatically created
-        2. Edit config file in a way that there is typo in sssd section name
-    :steps:
-        1. Call sssctl config-check
-        2. Check error message
-    :expectedresults:
-        1. config-check detects an error
-        2. Error message is properly set
-    :customerscenario: False
-    """
-    client.sssd.common.local()
-    client.sssd.start()
-    conf = re.sub(".sssd.", "[sssdx]", client.fs.read("/etc/sssd/sssd.conf"))
-    client.fs.write("/etc/sssd/sssd.conf", conf, mode="600")
-
-    result = client.sssctl.config_check()
-    assert result.rc != 0, "Config-check did not detect misconfigured config"
-    assert "Section [sssdx] is not allowed" in result.stdout, "Wrong error message on stdout"
-
-
-@pytest.mark.tools
-@pytest.mark.topology(KnownTopology.Client)
-def test_sssctl__check_invalid_pam_section_name(client: Client):
-    """
-    :title: Typo in pam section name
-    :setup:
-        1. Start SSSD, so default config is autimatically created
-        2. Edit config file in a way that there is typo in sssd section name
-    :steps:
-        1. Call sssctl config-check
-        2. Check error message
-    :expectedresults:
-        1. config-check detects an error
-        2. Error message is properly set
-    :customerscenario: False
-    """
-    client.sssd.common.local()
-    client.sssd.start()
-    conf = re.sub(".pam.", "[pamx]", client.fs.read("/etc/sssd/sssd.conf"))
-    client.fs.write("/etc/sssd/sssd.conf", conf, mode="600")
-
-    result = client.sssctl.config_check()
-    assert result.rc != 0, "Config-check did not detect misconfigured config"
-    assert "Section [pamx] is not allowed" in result.stdout, "Wrong error message on stdout"
-
-
-@pytest.mark.tools
-@pytest.mark.topology(KnownTopology.Client)
-def test_sssctl__check_invalid_nss_section_name(client: Client):
-    """
-    :title: Typo in nss section name
-    :setup:
-        1. Start SSSD, so default config is autimatically created
-        2. Edit config file in a way that there is typo in sssd section name
-    :steps:
-        1. Call sssctl config-check
-        2. Check error message
-    :expectedresults:
-        1. config-check detects an error
-        2. Error message is properly set
-    :customerscenario: False
-    """
-    client.sssd.common.local()
-    client.sssd.start()
-    conf = re.sub(".nss.", "[nssx]", client.fs.read("/etc/sssd/sssd.conf"))
-    client.fs.write("/etc/sssd/sssd.conf", conf, mode="600")
-
-    result = client.sssctl.config_check()
-    assert result.rc != 0, "Config-check did not detect misconfigured config"
-    assert "Section [nssx] is not allowed" in result.stdout, "Wrong error message on stdout"
-
-
-@pytest.mark.tools
-@pytest.mark.topology(KnownTopology.Client)
-def test_sssctl__check_invalid_permission(client: Client):
-    """
-    :title: Verify the permission of default configuration file
-    :setup:
-        1. Start SSSD, so default config is autimatically created
-        2. Change permission of default config file
-    :steps:
-        1. Call sssctl config-check
-        2. Check error message
-    :expectedresults:
-        1. config-check detects an error
-        2. Error message is properly set
-    :customerscenario: False
-    """
-    client.sssd.common.local()
-    client.sssd.start()
-    client.fs.chmod("0777", "/etc/sssd/sssd.conf")
-    result = client.sssctl.config_check()
-    assert result.rc != 0, "Config-check did not detect misconfigured config"
-    assert "File ownership and permissions check failed" in result.stdout, "Wrong error message on stdout"
-
-
-@pytest.mark.tools
-@pytest.mark.topology(KnownTopology.Client)
-def test_sssctl__check_missing_closing_bracket(client: Client):
-    """
-    :title: Missing closing bracket in sssd section name
-    :setup:
-        1. Start SSSD, so default config is autimatically created
-        2. Edit config file in a way that there is missing closing bracket
-    :steps:
-        1. Call sssctl config-check
-        2. Check error message
-    :expectedresults:
-        1. config-check detects an error
-        2. Error message is properly set
-    :customerscenario: False
-    """
-    client.sssd.common.local()
-    client.sssd.start()
-    conf = re.sub(".nss.", "[nssx", client.fs.read("/etc/sssd/sssd.conf"))
-    client.fs.write("/etc/sssd/sssd.conf", conf, mode="600")
-
-    result = client.sssctl.config_check()
-    assert result.rc != 0, "Config-check did not detect misconfigured config"
-    assert "No closing bracket" in result.stderr, "Wrong error message on stderr"
-
-
-@pytest.mark.tools
-@pytest.mark.topology(KnownTopology.Client)
-def test_sssctl__check_missing_opening_bracket(client: Client):
-    """
-    :title: Missing opening bracket in domain name
-    :setup:
-        1. Start SSSD, so default config is autimatically created
-        2. Edit config file in a way that there is missing opening bracket
-    :steps:
-        1. Call sssctl config-check
-        2. Check error message
-    :expectedresults:
-        1. config-check detects an error
-        2. Error message is properly set
-    :customerscenario: False
-        1. Is there no "No opening bracket" error like the closing bracket one?
-    """
-    client.sssd.common.local()
-    client.sssd.start()
-    conf = re.sub(".domain/local.", "domain/local]", client.fs.read("/etc/sssd/sssd.conf"))
-    client.fs.write("/etc/sssd/sssd.conf", conf, mode="600")
-
-    result = client.sssctl.config_check()
-    assert result.rc != 0, "Config-check did not detect misconfigured config"
-    assert "Equal sign is missing" in result.stderr, "Wrong error message on stderr"
-    assert "Failed to parse configuration" in result.stderr, "Wrong error message on stderr"
+    assert expected[0] in getattr(result, expected[1]), "Wrong error message on stderr"
 
 
 @pytest.mark.tools
@@ -768,14 +398,27 @@ def test_sssctl__check_ldap_host_object_class_in_domain(client: Client):
     assert result.rc == 0, "Config-check failed"
 
 
+@pytest.mark.importance("high")
 @pytest.mark.tools
 @pytest.mark.ticket(bz=1677994)
 @pytest.mark.topology(KnownTopology.Client)
-def test_sssctl__check_ldap_host_object_class_not_allowed_in_sssd(client: Client):
+@pytest.mark.parametrize(
+    "section,option,value,expected",
+    [
+        ("domain", "services", "nss, pam", "Attribute 'services' is not allowed in section 'domain/local'"),
+        (
+            "sssd",
+            "ldap_host_object_class",
+            "ipService",
+            "Attribute 'ldap_host_object_class' is not allowed in section 'sssd'",
+        ),
+    ],
+)
+def test_sssctl__check_attribute_not_allowed_in_sssd(client: Client, section, option, value, expected):
     """
-    :title: sssctl config-check do not allow ldap_host_object_class in sssd section
+    :title: sssctl config-check do not allow wrong attribute in sssd section
     :setup:
-        1. Add ldap_host_object_class to sssd section
+        1. Add wrong attribute to sssd section
         2. Start SSSD
     :steps:
         1. Call sssctl config-check
@@ -783,15 +426,14 @@ def test_sssctl__check_ldap_host_object_class_not_allowed_in_sssd(client: Client
         1. config-check succeed
     :customerscenario: True
     """
+    client.sssd.default_domain = "local"
     client.sssd.common.local()
-    client.sssd.sssd["ldap_host_object_class"] = "ipService"
+    getattr(client.sssd, section)[option] = value
     client.sssd.start(check_config=False)
 
     result = client.sssctl.config_check()
     assert result.rc != 0, "Config-check did not detect misconfigured config"
-    assert (
-        "Attribute 'ldap_host_object_class' is not allowed in section 'sssd'" in result.stdout
-    ), "Wrong error message on stdout"
+    assert expected in result.stdout, "Wrong error message on stdout"
 
 
 @pytest.mark.tools
@@ -851,63 +493,44 @@ def test_sssctl__check_auto_private_groups_in_child_domains(client: Client):
 @pytest.mark.tools
 @pytest.mark.ticket(bz=1723273)
 @pytest.mark.topology(KnownTopology.Client)
-def test_sssctl__check_non_default_config_location_missing_snippet_directory(client: Client):
+@pytest.mark.parametrize(
+    "option,default_conf_mode,dstpath,config,snippet,expected",
+    [
+        ("enabled", "0600", ("/tmp/test/", None), None, "/does/not/exist", "Directory /does/not/exist does not exist"),
+        (
+            "enabled",
+            "0600",
+            ("/tmp/test/", None),
+            "/tmp/test/sssd.conf",
+            None,
+            "Directory /tmp/test/conf.d does not exist",
+        ),
+        (
+            "enabled",
+            "0600",
+            ("/tmp/test/sssd.conf", "777"),
+            "/tmp/test/sssd.conf",
+            None,
+            "File ownership and permissions check failed",
+        ),
+        ("enabled", "0777", ("/tmp/test/", None), None, None, "File ownership and permissions check failed"),
+        (
+            "search_base",
+            "0600",
+            ("/tmp/test/", None),
+            "/tmp/test/sssd.conf",
+            None,
+            "Attribute 'search_base' is not allowed in section 'domain/local'",
+        ),
+    ],
+)
+def test_sssctl__check_config_location_permissions(
+    client: Client, option, default_conf_mode, dstpath, config, snippet, expected
+):
     """
-    :title: sssctl config-check complains about non existing snippet directory when config is non default
+    :title: sssctl config-check complains about wrong config location or permissions
     :setup:
-        1. Copy sssd.conf file to different directory
-    :steps:
-        1. Call sssctl config-check on that different directory
-        2. Check error message
-    :expectedresults:
-        1. config-check failed
-        2. Error message is properly set
-    :customerscenario: True
-    """
-    client.sssd.common.local()
-    client.sssd.config_apply()
-    client.fs.mkdir("/tmp/test/")
-    client.fs.copy("/etc/sssd/sssd.conf", "/tmp/test/")
-
-    result = client.sssctl.config_check(config="/tmp/test/sssd.conf")
-    assert result.rc != 0, "Config-check successfully finished"
-    assert "Directory /tmp/test/conf.d does not exist" in result.stdout, "Wrong error message on stdout"
-
-
-@pytest.mark.tools
-@pytest.mark.ticket(bz=1723273)
-@pytest.mark.topology(KnownTopology.Client)
-def test_sssctl__check_non_default_config_location_invalid_permission(client: Client):
-    """
-    :title: sssctl config-check complains about proper permission when config is non default
-    :setup:
-        1. Copy sssd.conf file to different directory and set it wrong permission
-    :steps:
-        1. Call sssctl config-check on that different directory
-        2. Check error message
-    :expectedresults:
-        1. config-check failed
-        2. Error message is properly set
-    :customerscenario: True
-    """
-    client.sssd.common.local()
-    client.sssd.config_apply()
-    client.fs.mkdir("/tmp/test/")
-    client.fs.copy("/etc/sssd/sssd.conf", "/tmp/test/sssd.conf", mode="777")
-
-    result = client.sssctl.config_check(config="/tmp/test/sssd.conf")
-    assert result.rc != 0, "Config-check successfully finished"
-    assert "File ownership and permissions check failed" in result.stdout, "Wrong error message on stdout"
-
-
-@pytest.mark.tools
-@pytest.mark.ticket(bz=1723273)
-@pytest.mark.topology(KnownTopology.Client)
-def test_sssctl__check_non_default_config_location_invalid_option_name(client: Client):
-    """
-    :title: sssctl config-check detects typo in option name when config is non default
-    :setup:
-        1. Copy sssd.conf file to different directory and mistype option name
+        1. Copy sssd.conf file to different directory and set wrong permissions
     :steps:
         1. Call sssctl config-check on that different directory
         2. Check error message
@@ -918,17 +541,16 @@ def test_sssctl__check_non_default_config_location_invalid_option_name(client: C
     """
     client.sssd.common.local()
     client.sssd.default_domain = "local"
-    client.sssd.domain["search_base"] = "True"
+    client.sssd.domain[option] = "true"
     client.sssd.config_apply(check_config=False)
 
     client.fs.mkdir("/tmp/test/")
-    client.fs.copy("/etc/sssd/sssd.conf", "/tmp/test/")
+    client.fs.chmod(default_conf_mode, "/etc/sssd/sssd.conf")
+    client.fs.copy("/etc/sssd/sssd.conf", dstpath[0], mode=dstpath[1])
 
-    result = client.sssctl.config_check(config="/tmp/test/sssd.conf")
+    result = client.sssctl.config_check(config=config, snippet=snippet)
     assert result.rc != 0, "Config-check successfully finished"
-    assert (
-        "Attribute 'search_base' is not allowed in section 'domain/local'" in result.stdout
-    ), "Wrong error message on stdout"
+    assert expected in result.stdout, "Wrong error message on stdout"
 
 
 @pytest.mark.tools
@@ -957,29 +579,6 @@ def test_sssctl__check_non_default_config_location_with_snippet_directory(client
     result = client.sssctl.config_check(config="/tmp/test/sssd.conf")
     assert result.rc == 0, "Config-check failed"
     assert "Directory /tmp/test/conf.d does not exist" not in result.stdout, "Wrong error message on stdout"
-
-
-@pytest.mark.tools
-@pytest.mark.ticket(bz=1723273)
-@pytest.mark.topology(KnownTopology.Client)
-def test_sssctl__check_non_existing_snippet(client: Client):
-    """
-    :title: sssctl config-check detects non existing snippet directory
-    :setup:
-        1. Start SSSD, so default config is autimatically created
-    :steps:
-        1. Call sssctl config-check with non existing snippet
-        2. Check error message
-    :expectedresults:
-        1. config-check failed
-        2. Error message is properly set
-    :customerscenario: True
-    """
-    client.sssd.common.local()
-    client.sssd.start()
-    result = client.sssctl.config_check(snippet="/does/not/exist")
-    assert result.rc != 0, "Config-check successfully finished"
-    assert "Directory /does/not/exist does not exist" in result.stdout, "Wrong error message on stdout"
 
 
 @pytest.mark.tools


### PR DESCRIPTION
- Combine various sssctl tests to the single parametrized tests.
- Mark bash sssctl tests that duplicates other tests with `-:`.


1) `test_sssctl__check_invalid_option_name_in_snippet` merges tests:

test_sssctl__check_invalid_option_name_in_snippet
test_sssctl__check_invalid_section_in_name_in_snippet 

2) `test_sssctl__check_invalid_section_name` merges tests:

test_sssctl__check_missing_equal_sign 
test_sssctl__check_invalid_id_provider 
test_sssctl__check_missing_id_provider
test_sssctl__check_special_character_in_option_name
test_sssctl__check_special_character_in_section_name
test_sssctl__check_special_character_in_domain_name
test_sssctl__check_forward_slash_missing_in_domain_section
test_sssctl__check_invalid_sssd_section_name
test_sssctl__check_missing_closing_bracket
test_sssctl__check_missing_opening_bracket

3) `test_sssctl__check_attribute_not_allowed_in_sssd` merges tests:

test_sssctl__check_misplaced_option
test_sssctl__check_ldap_host_object_class_not_allowed_in_sssd

4) `test_sssctl__check_config_location_permissions` merges tests:

test_sssctl__check_non_existing_snippet
test_sssctl__check_non_default_config_location_missing_snippet_directory
test_sssctl__check_invalid_permission
test_sssctl__check_non_default_config_location_invalid_permission
test_sssctl__check_non_default_config_location_invalid_option_name


5) Dropped tests:
test_sssctl__check_invalid_pam_section_name (duplicate test_sssctl__check_invalid_sssd_section_name)
test_sssctl__check_invalid_nss_section_name (duplicate test_sssctl__check_invalid_sssd_section_name)